### PR TITLE
Mention pastebin-haskell and ircbrowse

### DIFF
--- a/data/newsletter/issue-233.markdown
+++ b/data/newsletter/issue-233.markdown
@@ -19,7 +19,11 @@ undefined
 
 ## Show & tell
 
-undefined
+- [pastebin-haskell](https://github.com/tomsmeding/pastebin-haskell) by Tom Smeding
+  > A simple pastebin service for the `#haskell` IRC channel on Freenode, written in Haskell: [paste.tomsmeding.com](https://paste.tomsmeding.com).
+
+- [ircbrowse](https://github.com/tomsmeding/ircbrowse) by Chris Done &amp; Tom Smeding
+  > Originally by Chris Done, the IRC Browse service is [online again](https://ircbrowse.tomsmeding.com), and now builds with a recent GHC.
 
 ## Call for participation
 


### PR DESCRIPTION
These have been running for a few weeks now, and I was prompted in `#haskell` to submit them here. :)

I wasn't sure how to correctly state the attribution for `ircbrowse`; the project is originally by Chris Done, and I just made it work with the Haskell ecosystem of today and hosted it.