### PR TITLE
Fix CI on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,17 +19,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-east-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - uses: docker/setup-buildx-action@v1
-
-      - id: ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
       - id: haskell
         uses: actions/setup-haskell@v1
         with:
@@ -52,19 +41,10 @@ jobs:
 
       - run: cabal install --installdir docker --install-method copy
 
-      - run: cp --recursive data docker
-
       - uses: actions/upload-artifact@v2
         with:
           path: docker/haskellweekly
           name: haskellweekly-${{ github.sha }}
-
-      - uses: docker/build-push-action@v2
-        with:
-          context: docker
-          file: docker/Dockerfile
-          push: true
-          tags: ${{ steps.ecr.outputs.registry }}/haskellweekly-repository:${{ github.sha }}
 
   deploy:
     if: github.ref == 'refs/heads/haskellweekly'
@@ -79,6 +59,25 @@ jobs:
           aws-region: us-east-1
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - uses: docker/setup-buildx-action@v1
+
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - run: cp --recursive data docker
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: haskellweekly-${{ github.sha }}
+          path: docker/haskellweekly
+
+      - uses: docker/build-push-action@v2
+        with:
+          context: docker
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.ecr.outputs.registry }}/haskellweekly-repository:${{ github.sha }}
 
       - uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:


### PR DESCRIPTION
CI is broken on PRs because they don't have access to secrets. This PR should fix things by only building and pushing the Docker image (which requires credentials) when deploying. 