### PR TITLE
Add link pings

### DIFF
--- a/haskellweekly.cabal
+++ b/haskellweekly.cabal
@@ -74,6 +74,7 @@ library
     HW.Handler.Issue
     HW.Handler.Newsletter
     HW.Handler.NewsletterFeed
+    HW.Handler.Ping
     HW.Handler.Podcast
     HW.Handler.PodcastFeed
     HW.Handler.Redirect

--- a/haskellweekly.cabal
+++ b/haskellweekly.cabal
@@ -37,6 +37,7 @@ library
     , containers ^>= 0.6.2
     , cryptonite ^>= 0.27
     , filepath ^>= 1.4.2
+    , html-conduit ^>= 1.3.2
     , http-types ^>= 0.12.3
     , lucid ^>= 2.9.12
     , memory ^>= 0.15.0

--- a/src/lib/HW/Handler/Ping.hs
+++ b/src/lib/HW/Handler/Ping.hs
@@ -1,0 +1,34 @@
+module HW.Handler.Ping
+  ( handler
+  ) where
+
+import qualified Control.Monad.IO.Class as IO
+import qualified Data.ByteString as ByteString
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text
+import qualified HW.Handler.Common as Common
+import qualified HW.Type.App as App
+import qualified Network.HTTP.Types as Http
+import qualified Network.Wai as Wai
+import qualified Text.Printf as Printf
+
+handler :: Wai.Request -> App.App Wai.Response
+handler request = do
+  let headers = Wai.requestHeaders request
+  case (lookup hPingFrom headers, lookup hPingTo headers) of
+    (Just source, Just target) -> IO.liftIO $ Printf.printf
+      "PING %s %s\n"
+      (fromUtf8 source)
+      (fromUtf8 target)
+    _ -> pure ()
+  pure $ Common.status Http.ok200 []
+
+hPingFrom :: Http.HeaderName
+hPingFrom = "Ping-From"
+
+hPingTo :: Http.HeaderName
+hPingTo = "Ping-To"
+
+fromUtf8 :: ByteString.ByteString -> Text.Text
+fromUtf8 = Text.decodeUtf8With Text.lenientDecode

--- a/src/lib/HW/Middleware.hs
+++ b/src/lib/HW/Middleware.hs
@@ -167,48 +167,10 @@ addSecurityHeaders :: Wai.Middleware
 addSecurityHeaders =
   Wai.modifyResponse
     . Wai.mapResponseHeaders
-    $ addHeader "Content-Security-Policy" contentSecurityPolicy
-    . addHeader "Feature-Policy" featurePolicy
-    . addHeader "Referrer-Policy" "no-referrer"
+    $ addHeader "Referrer-Policy" "no-referrer"
     . addHeader "X-Content-Type-Options" "nosniff"
     . addHeader "X-Frame-Options" "deny"
     . addHeader "X-XSS-Protection" "1; mode=block"
-
--- | The value of the @Content-Security-Policy@ header.
--- <https://scotthelme.co.uk/content-security-policy-an-introduction/>
--- <https://www.ctrl.blog/entry/safari-csp-media-controls.html>
-contentSecurityPolicy :: Text.Text
-contentSecurityPolicy = Text.intercalate
-  "; "
-  [ "base-uri 'none'"
-  , "default-src 'none'"
-  , "form-action https://duckduckgo.com https://news.us10.list-manage.com 'self'"
-  , "frame-ancestors 'none'"
-  , "img-src data: 'self'"
-  , "media-src https://media.haskellweekly.news 'self'"
-  , "script-src 'unsafe-inline'"
-  , "style-src 'self'"
-  ]
-
--- | The value of the @Feature-Policy@ header.
--- <https://scotthelme.co.uk/a-new-security-header-feature-policy/>
-featurePolicy :: Text.Text
-featurePolicy = Text.intercalate
-  "; "
-  [ "camera 'none'"
-  , "fullscreen 'none'"
-  , "geolocation 'none'"
-  , "gyroscope 'none'"
-  , "magnetometer 'none'"
-  , "microphone 'none'"
-  , "midi 'none'"
-  , "notifications 'none'"
-  , "payment 'none'"
-  , "push 'none'"
-  , "speaker 'self'"
-  , "sync-xhr 'none'"
-  , "vibrate 'none'"
-  ]
 
 -- | Adds a header to a response. This doesn't remove any existing headers with
 -- the same name, so it's possible to end up with duplicates.

--- a/src/lib/HW/Template/Issue.hs
+++ b/src/lib/HW/Template/Issue.hs
@@ -24,6 +24,7 @@ template baseUrl issue markdown =
         Html.h2_ [Html.class_ "f2 mv3 tracked-tight"] $ Html.a_
           [ Html.class_ "no-underline purple"
           , Html.href_ $ Route.toText baseUrl Route.Newsletter
+          , Html.ping_ $ Route.toText baseUrl Route.Ping
           ]
           "Newsletter"
         Html.h3_ [Html.class_ "f3 mv3 tracked-tight"] $ do

--- a/src/lib/HW/Type/Route.hs
+++ b/src/lib/HW/Type/Route.hs
@@ -4,6 +4,7 @@
 module HW.Type.Route
   ( Route(..)
   , toText
+  , toTextRelative
   , fromText
   , routeContent
   ) where

--- a/src/lib/HW/Type/Route.hs
+++ b/src/lib/HW/Type/Route.hs
@@ -25,6 +25,7 @@ data Route
   | Logo
   | Newsletter
   | NewsletterFeed
+  | Ping
   | Podcast
   | PodcastFeed
   | Robots
@@ -49,6 +50,7 @@ toTextRelative route = case route of
   Logo -> "/logo.png"
   NewsletterFeed -> "/newsletter.atom"
   Newsletter -> "/newsletter.html"
+  Ping -> "/ping"
   PodcastFeed -> "/podcast.rss"
   Podcast -> "/podcast.html"
   Robots -> "/robots.txt"
@@ -78,6 +80,7 @@ fromText path = case path of
   ["logo.png"] -> Just Logo
   ["newsletter.atom"] -> Just NewsletterFeed
   ["newsletter.html"] -> Just Newsletter
+  ["ping"] -> Just Ping
   ["podcast.html"] -> Just Podcast
   ["podcast.rss"] -> Just PodcastFeed
   ["robots.txt"] -> Just Robots


### PR DESCRIPTION
The idea here is to collect some rudimentary analytics in a way that isn't super invasive. I recently learned about the `ping` attribute on `<a>` elements, which does exactly that. This PR adds `ping` to every `<a>` element, and adds a handler to log out pings. 

One thing I don't like about this is having to parse the HTML I just generated in order to walk over it. As far as I could tell neither CMark nor Lucid expose a way to do that. Also I end up rendering XML, which is a little weird. 