### PR TITLE
issue 294: Add Telecom Nancy Haskell course to show and tell

### DIFF
--- a/data/newsletter/issue-294.markdown
+++ b/data/newsletter/issue-294.markdown
@@ -26,7 +26,8 @@ undefined
 
 ## Show & tell
 
-undefined
+- [tn-fp-haskell-course](https://github.com/smelc/tn-fp-haskell-course) by Clément Hurlin
+  > I gave an 8 hours introduction to functional programming using Haskell to Senior students at [Telecom Nancy](https://telecomnancy.univ-lorraine.fr/). Students had a Java and python background, reception was very positive.
 
 ## Call for participation
 


### PR DESCRIPTION
I gave a Haskell course to senior students of a [computer science engineering school](https://telecomnancy.univ-lorraine.fr/). The [slides](https://smelc.github.io/tn-fp-haskell-course/slides/) of the course as well as the [exercises](https://github.com/smelc/tn-fp-haskell-course/tree/main/tps) are online, with the sources. I think it's a good fit for the next _Show & tell_.