### PR TITLE
Add a CFP issue for 364

### DIFF
--- a/data/newsletter/issue-364.markdown
+++ b/data/newsletter/issue-364.markdown
@@ -61,3 +61,4 @@ You should [advertise with us](https://haskellweekly.news/advertising.html)!
 ## Call for participation
 
 - [Cabal: `./Setup repl` is not documented (#8906)](https://github.com/haskell/cabal/issues/8906)
+- [poseidon-hs: Shorten excessively long genotype data parsing warnings just as we do with errors](https://github.com/poseidon-framework/poseidon-hs/issues/244)


### PR DESCRIPTION
Hi there! Looks like I can't push directly to `haskellweekly` anymore:

```
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 10 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 561 bytes | 561.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/haskellweekly.
remote: error: Changes must be made through a pull request. Required status check "GHC 9.4.4 on ubuntu" is expected.
To https://github.com/haskellweekly/haskellweekly
 ! [remote rejected] haskellweekly -> haskellweekly (protected branch hook declined)
error: failed to push some refs to 'https://github.com/haskellweekly/haskellweekly'
```

Potentially this is intentional so I am making a PR instead.