### PR TITLE
Fix branch name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - main
+      - haskellweekly
   push:
     branches:
-      - main
+      - haskellweekly
 
 jobs:
 


### PR DESCRIPTION
I really should rename the `haskellweekly` branch to `main` like everything else. 