### PR TITLE
Send emails with listmonk

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ a single Haskell web service. However it relies on some external services:
 - [GitHub](https://github.com):
   Hosts source code.
 
-- [Mailchimp](https://mailchimp.com):
-  Manages subscriber information and sends weekly emails.
-
 - [Square](https://squareup.com):
   Accepts payments for advertisements.
 

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,9 @@ image = "ghcr.io/haskellweekly/haskellweekly:latest"
 
 [env]
 BASE_URL = "https://haskellweekly.news"
+LISTMONK_LIST = "3"
+LISTMONK_URL = "https://listmonk.haskellweekly.news"
+LISTMONK_UUID = "4295554f-8f91-4864-92fa-a75a7315d630"
 
 [[services]]
 internal_port = 8080

--- a/haskellweekly.cabal
+++ b/haskellweekly.cabal
@@ -69,7 +69,7 @@ library
     uuid ^>=1.3.15,
     wai ^>=3.2.4,
     wai-extra ^>=3.1.15,
-    warp ^>=3.3.30,
+    warp ^>=3.4.1,
     xml-conduit ^>=1.9.1,
 
   default-extensions:

--- a/haskellweekly.cabal
+++ b/haskellweekly.cabal
@@ -37,6 +37,7 @@ common library
     -Wno-missing-deriving-strategies
     -Wno-missing-exported-signatures
     -Wno-missing-kind-signatures
+    -Wno-missing-role-annotations
     -Wno-missing-safe-haskell-mode
     -Wno-prepositive-qualified-module
     -Wno-safe
@@ -53,12 +54,16 @@ library
   import: library
   autogen-modules: Paths_haskellweekly
   build-depends:
+    aeson ^>=2.2.3,
+    async ^>=2.2.5,
     bytestring ^>=0.12.1,
     case-insensitive ^>=1.2.1,
     cmark ^>=0.6.1,
     containers ^>=0.7,
     crypton ^>=1.0.0,
     filepath ^>=1.5.2,
+    http-client ^>=0.7.17,
+    http-client-tls ^>=0.3.6,
     http-types ^>=0.12.4,
     lucid2 ^>=0.0.20240424,
     memory ^>=0.18.0,
@@ -127,6 +132,7 @@ library
     HW.Type.Episode
     HW.Type.Guid
     HW.Type.Issue
+    HW.Type.Listmonk
     HW.Type.Number
     HW.Type.Redirect
     HW.Type.Route
@@ -134,6 +140,7 @@ library
     HW.Type.State
     HW.Type.Summary
     HW.Type.Title
+    HW.Worker
     HaskellWeekly
 
   hs-source-dirs: source/library

--- a/source/library/HW/Handler/Issue.hs
+++ b/source/library/HW/Handler/Issue.hs
@@ -11,7 +11,6 @@ import qualified HW.Handler.Common as Common
 import qualified HW.Markdown as Markdown
 import qualified HW.Template.Issue as IssueTemplate
 import qualified HW.Type.App as App
-import qualified HW.Type.Config as Config
 import qualified HW.Type.Date as Date
 import qualified HW.Type.Issue as Issue
 import qualified HW.Type.Number as Number
@@ -28,10 +27,10 @@ handler number = do
     Nothing -> pure Common.notFound
     Just issue -> do
       node <- readIssueFile issue
-      let baseUrl = Config.baseUrl $ State.config state
+      let config = State.config state
       pure
         . Common.html Http.ok200 [(Http.hCacheControl, "public, max-age=900")]
-        $ IssueTemplate.template baseUrl issue node
+        $ IssueTemplate.template config issue node
 
 readIssueFile :: Issue.Issue -> App.App Markdown.Markdown
 readIssueFile issue = do

--- a/source/library/HW/Handler/Newsletter.hs
+++ b/source/library/HW/Handler/Newsletter.hs
@@ -23,6 +23,7 @@ handler = do
         List.sortOn (Ord.Down . Issue.issueNumber) . Map.elems $
           State.issues
             state
+      listmonk = Config.listmonk $ State.config state
   pure
     . Common.html Http.ok200 [(Http.hCacheControl, "public, max-age=900")]
-    $ Newsletter.template baseUrl issues
+    $ Newsletter.template baseUrl listmonk issues

--- a/source/library/HW/Handler/Newsletter.hs
+++ b/source/library/HW/Handler/Newsletter.hs
@@ -23,7 +23,7 @@ handler = do
         List.sortOn (Ord.Down . Issue.issueNumber) . Map.elems $
           State.issues
             state
-      listmonk = Config.listmonk $ State.config state
+      maybeListmonk = Config.listmonk $ State.config state
   pure
     . Common.html Http.ok200 [(Http.hCacheControl, "public, max-age=900")]
-    $ Newsletter.template baseUrl listmonk issues
+    $ Newsletter.template baseUrl maybeListmonk issues

--- a/source/library/HW/Main.hs
+++ b/source/library/HW/Main.hs
@@ -6,11 +6,13 @@ module HW.Main
   )
 where
 
+import qualified Control.Concurrent.Async as Async
 import qualified Data.IORef as IORef
 import qualified Data.Version as Version
 import qualified HW.Server as Server
 import qualified HW.Type.Config as Config
 import qualified HW.Type.State as State
+import qualified HW.Worker as Worker
 import qualified Paths_haskellweekly as Package
 import qualified System.IO as IO
 
@@ -25,4 +27,6 @@ defaultMain = do
   config <- Config.getConfig
   state <- State.configToState config
   stateRef <- IORef.newIORef state
-  Server.server stateRef
+  Async.race_
+    (Server.server stateRef)
+    (Worker.worker stateRef)

--- a/source/library/HW/Middleware.hs
+++ b/source/library/HW/Middleware.hs
@@ -185,14 +185,14 @@ addSecurityHeaders ref application request respond =
 -- | The value of the @Content-Security-Policy@ header.
 -- <https://scotthelme.co.uk/content-security-policy-an-introduction/>
 -- <https://www.ctrl.blog/entry/safari-csp-media-controls.html>
-contentSecurityPolicy :: Maybe Listmonk.Listmonk -> Text.Text
+contentSecurityPolicy :: Listmonk.Listmonk -> Text.Text
 contentSecurityPolicy listmonk =
   Text.intercalate
     "; "
     [ "base-uri 'none'",
       "default-src 'none'",
       "form-action https://duckduckgo.com "
-        <> maybe "" Listmonk.url listmonk
+        <> Listmonk.url listmonk
         <> " 'self'",
       "frame-ancestors 'none'",
       "img-src data: 'self'",

--- a/source/library/HW/Middleware.hs
+++ b/source/library/HW/Middleware.hs
@@ -172,9 +172,9 @@ sha1 = Crypto.hashlazy
 addSecurityHeaders :: IORef.IORef State.State -> Wai.Middleware
 addSecurityHeaders ref application request respond =
   application request $ \response -> do
-    listmonk <- Config.listmonk . State.config <$> IORef.readIORef ref
+    maybeListmonk <- Config.listmonk . State.config <$> IORef.readIORef ref
     let addHeaders =
-          addHeader "Content-Security-Policy" (contentSecurityPolicy listmonk)
+          addHeader "Content-Security-Policy" (contentSecurityPolicy maybeListmonk)
             . addHeader "Feature-Policy" featurePolicy
             . addHeader "Referrer-Policy" "no-referrer"
             . addHeader "X-Content-Type-Options" "nosniff"
@@ -185,14 +185,14 @@ addSecurityHeaders ref application request respond =
 -- | The value of the @Content-Security-Policy@ header.
 -- <https://scotthelme.co.uk/content-security-policy-an-introduction/>
 -- <https://www.ctrl.blog/entry/safari-csp-media-controls.html>
-contentSecurityPolicy :: Listmonk.Listmonk -> Text.Text
-contentSecurityPolicy listmonk =
+contentSecurityPolicy :: Maybe Listmonk.Listmonk -> Text.Text
+contentSecurityPolicy maybeListmonk =
   Text.intercalate
     "; "
     [ "base-uri 'none'",
       "default-src 'none'",
       "form-action https://duckduckgo.com "
-        <> Listmonk.url listmonk
+        <> maybe "" Listmonk.url maybeListmonk
         <> " 'self'",
       "frame-ancestors 'none'",
       "img-src data: 'self'",

--- a/source/library/HW/Middleware.hs
+++ b/source/library/HW/Middleware.hs
@@ -187,7 +187,7 @@ contentSecurityPolicy =
     "; "
     [ "base-uri 'none'",
       "default-src 'none'",
-      "form-action https://duckduckgo.com https://news.us10.list-manage.com 'self'",
+      "form-action https://duckduckgo.com https://listmonk.haskellweekly.news 'self'",
       "frame-ancestors 'none'",
       "img-src data: 'self'",
       "media-src https://media.haskellweekly.news 'self'",

--- a/source/library/HW/Template/Index.hs
+++ b/source/library/HW/Template/Index.hs
@@ -41,7 +41,7 @@ template config maybeIssue maybeEpisode = do
       "The Haskell Weekly Newsletter covers the Haskell programming language. "
       "Each issue features several hand-picked links to interesting content about Haskell from around the web."
     mapM_ (issueTemplate baseUrl) maybeIssue
-    Newsletter.callToAction baseUrl
+    Newsletter.callToAction baseUrl $ Config.listmonk config
     Html.h2_ [Html.class_ "f2 mv3 tracked-tight"] $
       Html.a_
         [ Html.class_ "no-underline purple",

--- a/source/library/HW/Template/Issue.hs
+++ b/source/library/HW/Template/Issue.hs
@@ -7,7 +7,7 @@ import qualified Data.Text as Text
 import qualified HW.Markdown as Markdown
 import qualified HW.Template.Base as Base
 import qualified HW.Template.Newsletter as Newsletter
-import qualified HW.Type.BaseUrl as BaseUrl
+import qualified HW.Type.Config as Config
 import qualified HW.Type.Date as Date
 import qualified HW.Type.Issue as Issue
 import qualified HW.Type.Number as Number
@@ -15,8 +15,9 @@ import qualified HW.Type.Route as Route
 import qualified Lucid as Html
 
 template ::
-  BaseUrl.BaseUrl -> Issue.Issue -> Markdown.Markdown -> Html.Html ()
-template baseUrl issue markdown =
+  Config.Config -> Issue.Issue -> Markdown.Markdown -> Html.Html ()
+template config issue markdown = do
+  let baseUrl = Config.baseUrl config
   Base.template
     baseUrl
     (title issue <> " :: Haskell Weekly Newsletter")
@@ -32,7 +33,7 @@ template baseUrl issue markdown =
         Html.toHtml $ title issue
         " "
         Html.span_ [Html.class_ "mid-gray"] . Html.toHtml $ date issue
-      Newsletter.callToAction baseUrl
+      Newsletter.callToAction baseUrl $ Config.listmonk config
       Html.div_ . Html.toHtmlRaw $ Markdown.toHtml markdown
 
 title :: Issue.Issue -> Text.Text

--- a/source/library/HW/Template/Newsletter.hs
+++ b/source/library/HW/Template/Newsletter.hs
@@ -65,26 +65,24 @@ callToAction baseUrl =
         "the archives"
       "."
     Html.form_
-      [ Html.action_
-          "https://news.us10.list-manage.com/subscribe/post?u=49a6a2e17b12be2c5c4dcb232&id=ffbbbbd930",
+      [ Html.action_ "https://listmonk.haskellweekly.news/subscription/form",
         Html.class_ "flex",
         Html.method_ "post"
       ]
       $ do
-        Html.div_
-          [ Html.makeAttributes "aria-hidden" "true",
-            Html.class_ "absolute f7 top--2"
+        Html.input_
+          [ Html.name_ "nonce",
+            Html.type_ "hidden"
           ]
-          $ Html.input_
-            [ Html.name_ "b_49a6a2e17b12be2c5c4dcb232_ffbbbbd930",
-              Html.tabindex_ "-1",
-              Html.type_ "text",
-              Html.value_ ""
-            ]
+        Html.input_
+          [ Html.name_ "l",
+            Html.type_ "hidden",
+            Html.value_ "4295554f-8f91-4864-92fa-a75a7315d630"
+          ]
         Html.input_
           [ Html.makeAttributes "aria-label" "Email address",
             Html.class_ "ba br0 b--silver input-reset pa3 flex-auto",
-            Html.name_ "EMAIL",
+            Html.name_ "email",
             Html.placeholder_ "you@example.com",
             Html.required_ "required",
             Html.type_ "email"

--- a/source/library/HW/Template/Newsletter.hs
+++ b/source/library/HW/Template/Newsletter.hs
@@ -5,6 +5,7 @@ module HW.Template.Newsletter
   )
 where
 
+import qualified Data.UUID as Uuid
 import qualified HW.Template.Base as Base
 import qualified HW.Template.Common as Common
 import qualified HW.Type.BaseUrl as BaseUrl
@@ -78,7 +79,7 @@ callToAction baseUrl listmonk =
         Html.input_
           [ Html.name_ "l",
             Html.type_ "hidden",
-            Html.value_ "4295554f-8f91-4864-92fa-a75a7315d630"
+            Html.value_ . Uuid.toText $ Listmonk.uuid listmonk
           ]
         Html.input_
           [ Html.makeAttributes "aria-label" "Email address",

--- a/source/library/HW/Template/Newsletter.hs
+++ b/source/library/HW/Template/Newsletter.hs
@@ -5,7 +5,6 @@ module HW.Template.Newsletter
   )
 where
 
-import qualified Control.Monad as Monad
 import qualified HW.Template.Base as Base
 import qualified HW.Template.Common as Common
 import qualified HW.Type.BaseUrl as BaseUrl
@@ -17,7 +16,7 @@ import qualified HW.Type.Route as Route
 import qualified Lucid as Html
 import qualified Lucid.Base as Html
 
-template :: BaseUrl.BaseUrl -> Maybe Listmonk.Listmonk -> [Issue.Issue] -> Html.Html ()
+template :: BaseUrl.BaseUrl -> Listmonk.Listmonk -> [Issue.Issue] -> Html.Html ()
 template baseUrl listmonk issues =
   Base.template baseUrl "Haskell Weekly Newsletter" (header baseUrl Nothing) $
     do
@@ -51,50 +50,49 @@ header baseUrl maybeIssue = do
         . Route.Issue
         $ Issue.issueNumber issue
 
-callToAction :: BaseUrl.BaseUrl -> Maybe Listmonk.Listmonk -> Html.Html ()
+callToAction :: BaseUrl.BaseUrl -> Listmonk.Listmonk -> Html.Html ()
 callToAction baseUrl listmonk =
-  Monad.forM_ (fmap Listmonk.url listmonk) $ \url ->
-    Html.div_ [Html.class_ "ba b--yellow bg-washed-yellow center mw6 pa3"] $ do
-      Html.p_ [Html.class_ "mt0"] $ do
-        "Subscribe now! "
-        "We'll never send you spam. "
-        "You can also follow "
-        Html.a_
-          [Html.href_ $ Route.toText baseUrl Route.NewsletterFeed]
-          "our feed"
-        ". Read more issues in "
-        Html.a_
-          [Html.href_ $ Route.toText baseUrl Route.Newsletter]
-          "the archives"
-        "."
-      Html.form_
-        [ Html.action_ $ url <> "/subscription/form",
-          Html.class_ "flex",
-          Html.method_ "post"
-        ]
-        $ do
-          Html.input_
-            [ Html.name_ "nonce",
-              Html.type_ "hidden"
-            ]
-          Html.input_
-            [ Html.name_ "l",
-              Html.type_ "hidden",
-              Html.value_ "4295554f-8f91-4864-92fa-a75a7315d630"
-            ]
-          Html.input_
-            [ Html.makeAttributes "aria-label" "Email address",
-              Html.class_ "ba br0 b--silver input-reset pa3 flex-auto",
-              Html.name_ "email",
-              Html.placeholder_ "you@example.com",
-              Html.required_ "required",
-              Html.type_ "email"
-            ]
-          Html.button_
-            [ Html.class_ "b bn bg-dark-blue input-reset pa3 pointer white",
-              Html.type_ "submit"
-            ]
-            "Subscribe"
+  Html.div_ [Html.class_ "ba b--yellow bg-washed-yellow center mw6 pa3"] $ do
+    Html.p_ [Html.class_ "mt0"] $ do
+      "Subscribe now! "
+      "We'll never send you spam. "
+      "You can also follow "
+      Html.a_
+        [Html.href_ $ Route.toText baseUrl Route.NewsletterFeed]
+        "our feed"
+      ". Read more issues in "
+      Html.a_
+        [Html.href_ $ Route.toText baseUrl Route.Newsletter]
+        "the archives"
+      "."
+    Html.form_
+      [ Html.action_ $ Listmonk.url listmonk <> "/subscription/form",
+        Html.class_ "flex",
+        Html.method_ "post"
+      ]
+      $ do
+        Html.input_
+          [ Html.name_ "nonce",
+            Html.type_ "hidden"
+          ]
+        Html.input_
+          [ Html.name_ "l",
+            Html.type_ "hidden",
+            Html.value_ "4295554f-8f91-4864-92fa-a75a7315d630"
+          ]
+        Html.input_
+          [ Html.makeAttributes "aria-label" "Email address",
+            Html.class_ "ba br0 b--silver input-reset pa3 flex-auto",
+            Html.name_ "email",
+            Html.placeholder_ "you@example.com",
+            Html.required_ "required",
+            Html.type_ "email"
+          ]
+        Html.button_
+          [ Html.class_ "b bn bg-dark-blue input-reset pa3 pointer white",
+            Html.type_ "submit"
+          ]
+          "Subscribe"
 
 issueTemplate :: BaseUrl.BaseUrl -> Issue.Issue -> Html.Html ()
 issueTemplate baseUrl issue = Html.li_ $ do

--- a/source/library/HW/Template/Newsletter.hs
+++ b/source/library/HW/Template/Newsletter.hs
@@ -5,25 +5,27 @@ module HW.Template.Newsletter
   )
 where
 
+import qualified Control.Monad as Monad
 import qualified HW.Template.Base as Base
 import qualified HW.Template.Common as Common
 import qualified HW.Type.BaseUrl as BaseUrl
 import qualified HW.Type.Date as Date
 import qualified HW.Type.Issue as Issue
+import qualified HW.Type.Listmonk as Listmonk
 import qualified HW.Type.Number as Number
 import qualified HW.Type.Route as Route
 import qualified Lucid as Html
 import qualified Lucid.Base as Html
 
-template :: BaseUrl.BaseUrl -> [Issue.Issue] -> Html.Html ()
-template baseUrl issues =
+template :: BaseUrl.BaseUrl -> Maybe Listmonk.Listmonk -> [Issue.Issue] -> Html.Html ()
+template baseUrl listmonk issues =
   Base.template baseUrl "Haskell Weekly Newsletter" (header baseUrl Nothing) $
     do
       Html.h2_ [Html.class_ "f2 mv3 tracked-tight"] "Newsletter"
       Html.p_ $ do
         "The Haskell Weekly Newsletter covers the Haskell programming language. "
         "Each issue features several hand-picked links to interesting content about Haskell from around the web."
-      callToAction baseUrl
+      callToAction baseUrl listmonk
       Html.ul_ $ mapM_ (issueTemplate baseUrl) issues
 
 header :: BaseUrl.BaseUrl -> Maybe Issue.Issue -> Html.Html ()
@@ -49,49 +51,50 @@ header baseUrl maybeIssue = do
         . Route.Issue
         $ Issue.issueNumber issue
 
-callToAction :: BaseUrl.BaseUrl -> Html.Html ()
-callToAction baseUrl =
-  Html.div_ [Html.class_ "ba b--yellow bg-washed-yellow center mw6 pa3"] $ do
-    Html.p_ [Html.class_ "mt0"] $ do
-      "Subscribe now! "
-      "We'll never send you spam. "
-      "You can also follow "
-      Html.a_
-        [Html.href_ $ Route.toText baseUrl Route.NewsletterFeed]
-        "our feed"
-      ". Read more issues in "
-      Html.a_
-        [Html.href_ $ Route.toText baseUrl Route.Newsletter]
-        "the archives"
-      "."
-    Html.form_
-      [ Html.action_ "https://listmonk.haskellweekly.news/subscription/form",
-        Html.class_ "flex",
-        Html.method_ "post"
-      ]
-      $ do
-        Html.input_
-          [ Html.name_ "nonce",
-            Html.type_ "hidden"
-          ]
-        Html.input_
-          [ Html.name_ "l",
-            Html.type_ "hidden",
-            Html.value_ "4295554f-8f91-4864-92fa-a75a7315d630"
-          ]
-        Html.input_
-          [ Html.makeAttributes "aria-label" "Email address",
-            Html.class_ "ba br0 b--silver input-reset pa3 flex-auto",
-            Html.name_ "email",
-            Html.placeholder_ "you@example.com",
-            Html.required_ "required",
-            Html.type_ "email"
-          ]
-        Html.button_
-          [ Html.class_ "b bn bg-dark-blue input-reset pa3 pointer white",
-            Html.type_ "submit"
-          ]
-          "Subscribe"
+callToAction :: BaseUrl.BaseUrl -> Maybe Listmonk.Listmonk -> Html.Html ()
+callToAction baseUrl listmonk =
+  Monad.forM_ (fmap Listmonk.url listmonk) $ \url ->
+    Html.div_ [Html.class_ "ba b--yellow bg-washed-yellow center mw6 pa3"] $ do
+      Html.p_ [Html.class_ "mt0"] $ do
+        "Subscribe now! "
+        "We'll never send you spam. "
+        "You can also follow "
+        Html.a_
+          [Html.href_ $ Route.toText baseUrl Route.NewsletterFeed]
+          "our feed"
+        ". Read more issues in "
+        Html.a_
+          [Html.href_ $ Route.toText baseUrl Route.Newsletter]
+          "the archives"
+        "."
+      Html.form_
+        [ Html.action_ $ url <> "/subscription/form",
+          Html.class_ "flex",
+          Html.method_ "post"
+        ]
+        $ do
+          Html.input_
+            [ Html.name_ "nonce",
+              Html.type_ "hidden"
+            ]
+          Html.input_
+            [ Html.name_ "l",
+              Html.type_ "hidden",
+              Html.value_ "4295554f-8f91-4864-92fa-a75a7315d630"
+            ]
+          Html.input_
+            [ Html.makeAttributes "aria-label" "Email address",
+              Html.class_ "ba br0 b--silver input-reset pa3 flex-auto",
+              Html.name_ "email",
+              Html.placeholder_ "you@example.com",
+              Html.required_ "required",
+              Html.type_ "email"
+            ]
+          Html.button_
+            [ Html.class_ "b bn bg-dark-blue input-reset pa3 pointer white",
+              Html.type_ "submit"
+            ]
+            "Subscribe"
 
 issueTemplate :: BaseUrl.BaseUrl -> Issue.Issue -> Html.Html ()
 issueTemplate baseUrl issue = Html.li_ $ do

--- a/source/library/HW/Type/Config.hs
+++ b/source/library/HW/Type/Config.hs
@@ -18,7 +18,7 @@ data Config = Config
   { baseUrl :: BaseUrl.BaseUrl,
     dataDirectory :: FilePath,
     googleSiteVerification :: Maybe Text.Text,
-    listmonk :: Maybe Listmonk.Listmonk,
+    listmonk :: Listmonk.Listmonk,
     port :: Warp.Port
   }
   deriving (Eq, Show)

--- a/source/library/HW/Type/Config.hs
+++ b/source/library/HW/Type/Config.hs
@@ -8,6 +8,7 @@ where
 
 import qualified Data.Text as Text
 import qualified HW.Type.BaseUrl as BaseUrl
+import qualified HW.Type.Listmonk as Listmonk
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Paths_haskellweekly as Package
 import qualified System.Environment as Environment
@@ -17,6 +18,7 @@ data Config = Config
   { baseUrl :: BaseUrl.BaseUrl,
     dataDirectory :: FilePath,
     googleSiteVerification :: Maybe Text.Text,
+    listmonk :: Maybe Listmonk.Listmonk,
     port :: Warp.Port
   }
   deriving (Eq, Show)
@@ -30,7 +32,8 @@ getConfig = do
   googleSiteVerification <- getGoogleSiteVerification
   port <- getPort
   baseUrl <- getBaseUrl
-  pure Config {baseUrl, dataDirectory, googleSiteVerification, port}
+  listmonk <- Listmonk.getListmonk
+  pure Config {baseUrl, dataDirectory, googleSiteVerification, listmonk, port}
 
 -- | Gets the base URL that the server will be available at. This is necessary
 -- because the server could be behind a reverse proxy or in a container or

--- a/source/library/HW/Type/Config.hs
+++ b/source/library/HW/Type/Config.hs
@@ -23,8 +23,7 @@ data Config = Config
 
 -- | Gets all the necessary pieces of the 'Config' and stitches them together.
 -- Note that even if the config is valid, the server might fail to start. For
--- example if the database URL is syntactically valid but the database doesn't
--- actually exist.
+-- example if the data directory doesn't actually exist.
 getConfig :: IO Config
 getConfig = do
   dataDirectory <- Package.getDataDir

--- a/source/library/HW/Type/Config.hs
+++ b/source/library/HW/Type/Config.hs
@@ -18,7 +18,7 @@ data Config = Config
   { baseUrl :: BaseUrl.BaseUrl,
     dataDirectory :: FilePath,
     googleSiteVerification :: Maybe Text.Text,
-    listmonk :: Listmonk.Listmonk,
+    listmonk :: Maybe Listmonk.Listmonk,
     port :: Warp.Port
   }
   deriving (Eq, Show)

--- a/source/library/HW/Type/Listmonk.hs
+++ b/source/library/HW/Type/Listmonk.hs
@@ -1,0 +1,26 @@
+module HW.Type.Listmonk
+  ( Listmonk (..),
+    getListmonk,
+  )
+where
+
+import qualified Control.Monad.Trans.Maybe as MaybeT
+import qualified Data.Text as Text
+import qualified System.Environment as Environment
+import qualified Text.Read as Read
+
+data Listmonk = Listmonk
+  { list :: Int,
+    password :: Text.Text,
+    url :: Text.Text,
+    username :: Text.Text
+  }
+  deriving (Eq, Show)
+
+getListmonk :: IO (Maybe Listmonk)
+getListmonk = MaybeT.runMaybeT $ do
+  list <- MaybeT.MaybeT . fmap (>>= Read.readMaybe) $ Environment.lookupEnv "LISTMONK_LIST"
+  password <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_PASSWORD"
+  url <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_URL"
+  username <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_USERNAME"
+  pure Listmonk {list, password, url, username}

--- a/source/library/HW/Type/Listmonk.hs
+++ b/source/library/HW/Type/Listmonk.hs
@@ -4,7 +4,6 @@ module HW.Type.Listmonk
   )
 where
 
-import qualified Control.Monad.Trans.Maybe as MaybeT
 import qualified Data.Text as Text
 import qualified System.Environment as Environment
 import qualified Text.Read as Read
@@ -17,10 +16,14 @@ data Listmonk = Listmonk
   }
   deriving (Eq, Show)
 
-getListmonk :: IO (Maybe Listmonk)
-getListmonk = MaybeT.runMaybeT $ do
-  list <- MaybeT.MaybeT . fmap (>>= Read.readMaybe) $ Environment.lookupEnv "LISTMONK_LIST"
-  password <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_PASSWORD"
-  url <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_URL"
-  username <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_USERNAME"
+getListmonk :: IO Listmonk
+getListmonk = do
+  list <- do
+    string <- Environment.getEnv "LISTMONK_LIST"
+    case Read.readMaybe string of
+      Nothing -> fail $ "invalid LISTMONK_LIST: " <> show string
+      Just list -> pure list
+  password <- Text.pack <$> Environment.getEnv "LISTMONK_PASSWORD"
+  url <- Text.pack <$> Environment.getEnv "LISTMONK_URL"
+  username <- Text.pack <$> Environment.getEnv "LISTMONK_USERNAME"
   pure Listmonk {list, password, url, username}

--- a/source/library/HW/Type/Listmonk.hs
+++ b/source/library/HW/Type/Listmonk.hs
@@ -4,6 +4,7 @@ module HW.Type.Listmonk
   )
 where
 
+import qualified Control.Monad.Trans.Maybe as MaybeT
 import qualified Data.Text as Text
 import qualified Data.UUID as Uuid
 import qualified System.Environment as Environment
@@ -18,18 +19,18 @@ data Listmonk = Listmonk
   }
   deriving (Eq, Show)
 
-getListmonk :: IO Listmonk
-getListmonk = do
+getListmonk :: IO (Maybe Listmonk)
+getListmonk = MaybeT.runMaybeT $ do
   list <- do
-    string <- Environment.getEnv "LISTMONK_LIST"
+    string <- MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_LIST"
     case Read.readMaybe string of
       Nothing -> fail $ "invalid LISTMONK_LIST: " <> show string
       Just list -> pure list
-  password <- Text.pack <$> Environment.getEnv "LISTMONK_PASSWORD"
-  url <- Text.pack <$> Environment.getEnv "LISTMONK_URL"
-  username <- Text.pack <$> Environment.getEnv "LISTMONK_USERNAME"
+  password <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_PASSWORD"
+  url <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_URL"
+  username <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_USERNAME"
   uuid <- do
-    string <- Environment.getEnv "LISTMONK_UUID"
+    string <- MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_UUID"
     case Uuid.fromString string of
       Nothing -> fail $ "invalid LISTMONK_UUID: " <> show string
       Just uuid -> pure uuid

--- a/source/library/HW/Type/Listmonk.hs
+++ b/source/library/HW/Type/Listmonk.hs
@@ -5,6 +5,7 @@ module HW.Type.Listmonk
 where
 
 import qualified Data.Text as Text
+import qualified Data.UUID as Uuid
 import qualified System.Environment as Environment
 import qualified Text.Read as Read
 
@@ -12,7 +13,8 @@ data Listmonk = Listmonk
   { list :: Int,
     password :: Text.Text,
     url :: Text.Text,
-    username :: Text.Text
+    username :: Text.Text,
+    uuid :: Uuid.UUID
   }
   deriving (Eq, Show)
 
@@ -26,4 +28,9 @@ getListmonk = do
   password <- Text.pack <$> Environment.getEnv "LISTMONK_PASSWORD"
   url <- Text.pack <$> Environment.getEnv "LISTMONK_URL"
   username <- Text.pack <$> Environment.getEnv "LISTMONK_USERNAME"
-  pure Listmonk {list, password, url, username}
+  uuid <- do
+    string <- Environment.getEnv "LISTMONK_UUID"
+    case Uuid.fromString string of
+      Nothing -> fail $ "invalid LISTMONK_UUID: " <> show string
+      Just uuid -> pure uuid
+  pure Listmonk {list, password, url, username, uuid}

--- a/source/library/HW/Type/State.hs
+++ b/source/library/HW/Type/State.hs
@@ -15,6 +15,8 @@ import qualified Data.Time as Time
 import qualified HW.Episodes as Episodes
 import qualified HW.Issues as Issues
 import qualified HW.Type.Config as Config
+import qualified Network.HTTP.Client as Client
+import qualified Network.HTTP.Client.TLS as Tls
 import qualified Network.Wai as Wai
 
 data State = State
@@ -22,6 +24,7 @@ data State = State
     episodes :: Episodes.Episodes,
     fileCache :: Map.Map FilePath ByteString.ByteString,
     issues :: Issues.Issues,
+    manager :: Client.Manager,
     responseCache ::
       Map.Map (Text.Text, Text.Text) (Time.UTCTime, Wai.Response)
   }
@@ -32,12 +35,14 @@ configToState :: Config.Config -> IO State
 configToState config = do
   episodes <- either fail pure Episodes.episodes
   issues <- either fail pure Issues.issues
+  manager <- Tls.newTlsManager
   pure
     State
       { config,
         episodes,
         fileCache = Map.empty,
         issues,
+        manager,
         responseCache = Map.empty
       }
 

--- a/source/library/HW/Worker.hs
+++ b/source/library/HW/Worker.hs
@@ -45,6 +45,8 @@ worker stateRef = Monad.forever $ do
           let username = Encoding.encodeUtf8 $ Listmonk.username listmonk
           let password = Encoding.encodeUtf8 $ Listmonk.password listmonk
           let name = "hwn-" <> Date.toShortText (Issue.issueDate issue)
+          -- `?query=x` becomes `like '%x%'`, so this will match any substring.
+          -- That's why we search for `hwn-YYYY-MM-DD` rather than `issue-NNN`.
           let query = Http.renderQuery True [("query", Just $ Encoding.encodeUtf8 name)]
           getResponse <-
             Client.httpLbs

--- a/source/library/HW/Worker.hs
+++ b/source/library/HW/Worker.hs
@@ -1,0 +1,136 @@
+module HW.Worker (worker) where
+
+import qualified CMark
+import qualified Control.Concurrent as Concurrent
+import qualified Control.Monad as Monad
+import qualified Control.Monad.Trans.Reader as Reader
+import qualified Data.Aeson as Aeson
+import qualified Data.IORef as IORef
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
+import qualified Data.Ord as Ord
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Encoding
+import qualified Data.Time as Time
+import qualified HW.Handler.Issue as Issue
+import qualified HW.Type.Config as Config
+import qualified HW.Type.Date as Date
+import qualified HW.Type.Issue as Issue
+import qualified HW.Type.Listmonk as Listmonk
+import qualified HW.Type.Number as Number
+import qualified HW.Type.State as State
+import qualified Network.HTTP.Client as Client
+import qualified Network.HTTP.Types as Http
+
+worker :: IORef.IORef State.State -> IO ()
+worker stateRef = Monad.forever $ do
+  now <- Time.getCurrentTime
+  putStrLn $ "[worker] running at " <> Time.formatTime Time.defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" now
+  state <- IORef.readIORef stateRef
+  case Config.listmonk $ State.config state of
+    Nothing -> putStrLn "[worker] missing listmonk config"
+    Just listmonk -> do
+      let maybeLatest =
+            Maybe.listToMaybe
+              . List.sortOn (Ord.Down . Issue.issueDate)
+              . Map.elems
+              $ State.issues state
+      case maybeLatest of
+        Nothing -> putStrLn "[worker] no issues"
+        Just issue -> do
+          let url = Listmonk.url listmonk
+          getRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"
+          let username = Encoding.encodeUtf8 $ Listmonk.username listmonk
+          let password = Encoding.encodeUtf8 $ Listmonk.password listmonk
+          let name = "hwn-" <> Date.toShortText (Issue.issueDate issue)
+          let query = Http.renderQuery True [("query", Just $ Encoding.encodeUtf8 name)]
+          getResponse <-
+            Client.httpLbs
+              (Client.applyBasicAuth username password getRequest) {Client.queryString = query}
+              (State.manager state)
+          case Aeson.eitherDecode $ Client.responseBody getResponse of
+            Left err -> putStrLn $ "[worker] failed to parse campaigns: " <> err
+            Right campaigns -> do
+              if campaignsTotal (payloadData campaigns) /= 0
+                then putStrLn $ "[worker] campaign " <> show name <> " already exists"
+                else do
+                  postRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"
+                  let number = Number.toText $ Issue.issueNumber issue
+                  node <- Reader.runReaderT (Issue.readIssueFile issue) stateRef
+                  let text = CMark.nodeToCommonmark [] Nothing node
+                  let list = Listmonk.list listmonk
+                  let campaign =
+                        Campaign
+                          { campaignBody = "# Haskell Weekly\n\n## Issue " <> number <> "\n\n" <> text,
+                            campaignContentType = Just "markdown",
+                            campaignLists = pure list,
+                            campaignName = name,
+                            campaignSubject = "Issue " <> number
+                          }
+                  postResponse <-
+                    Client.httpLbs
+                      ( Client.applyBasicAuth
+                          username
+                          password
+                          postRequest
+                            { Client.method = Http.methodPost,
+                              Client.requestBody = Client.RequestBodyLBS $ Aeson.encode campaign,
+                              Client.requestHeaders = [(Http.hContentType, "application/json")]
+                            }
+                      )
+                      (State.manager state)
+                  case Aeson.eitherDecode $ Client.responseBody postResponse of
+                    Left err -> putStrLn $ "[worker] failed to parse campaign: " <> err
+                    Right result -> putStrLn $ "[worker] created campaign " <> show (resultId $ payloadData result)
+  Concurrent.threadDelay $ 60 * 1000 * 1000
+
+newtype Payload a = Payload
+  { payloadData :: a
+  }
+  deriving (Eq, Show)
+
+instance (Aeson.FromJSON a) => Aeson.FromJSON (Payload a) where
+  parseJSON = Aeson.withObject "Payload" $ \object -> do
+    data_ <- object Aeson..: "data"
+    pure Payload {payloadData = data_}
+
+newtype Campaigns = Campaigns
+  { campaignsTotal :: Int
+  }
+  deriving (Eq, Show)
+
+instance Aeson.FromJSON Campaigns where
+  parseJSON = Aeson.withObject "Campaigns" $ \object -> do
+    total <- object Aeson..: "total"
+    pure Campaigns {campaignsTotal = total}
+
+data Campaign = Campaign
+  { campaignBody :: Text.Text,
+    campaignContentType :: Maybe Text.Text,
+    campaignLists :: NonEmpty.NonEmpty Int,
+    campaignName :: Text.Text,
+    campaignSubject :: Text.Text
+  }
+  deriving (Eq, Show)
+
+instance Aeson.ToJSON Campaign where
+  toJSON x =
+    Aeson.object
+      [ "body" Aeson..= campaignBody x,
+        "content_type" Aeson..= campaignContentType x,
+        "lists" Aeson..= campaignLists x,
+        "name" Aeson..= campaignName x,
+        "subject" Aeson..= campaignSubject x
+      ]
+
+newtype Result = Result
+  { resultId :: Int
+  }
+  deriving (Eq, Show)
+
+instance Aeson.FromJSON Result where
+  parseJSON = Aeson.withObject "Result" $ \object -> do
+    id_ <- object Aeson..: "id"
+    pure Result {resultId = id_}

--- a/source/library/HW/Worker.hs
+++ b/source/library/HW/Worker.hs
@@ -29,63 +29,61 @@ worker stateRef = Monad.forever $ do
   now <- Time.getCurrentTime
   putStrLn $ "[worker] running at " <> Time.formatTime Time.defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" now
   state <- IORef.readIORef stateRef
-  case Config.listmonk $ State.config state of
-    Nothing -> putStrLn "[worker] missing listmonk config"
-    Just listmonk -> do
-      let maybeLatest =
-            Maybe.listToMaybe
-              . List.sortOn (Ord.Down . Issue.issueDate)
-              . Map.elems
-              $ State.issues state
-      case maybeLatest of
-        Nothing -> putStrLn "[worker] no issues"
-        Just issue -> do
-          let url = Listmonk.url listmonk
-          getRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"
-          let username = Encoding.encodeUtf8 $ Listmonk.username listmonk
-          let password = Encoding.encodeUtf8 $ Listmonk.password listmonk
-          let name = "hwn-" <> Date.toShortText (Issue.issueDate issue)
-          -- `?query=x` becomes `like '%x%'`, so this will match any substring.
-          -- That's why we search for `hwn-YYYY-MM-DD` rather than `issue-NNN`.
-          let query = Http.renderQuery True [("query", Just $ Encoding.encodeUtf8 name)]
-          getResponse <-
-            Client.httpLbs
-              (Client.applyBasicAuth username password getRequest) {Client.queryString = query}
-              (State.manager state)
-          case Aeson.eitherDecode $ Client.responseBody getResponse of
-            Left err -> putStrLn $ "[worker] failed to parse campaigns: " <> err
-            Right campaigns -> do
-              if campaignsTotal (payloadData campaigns) /= 0
-                then putStrLn $ "[worker] campaign " <> show name <> " already exists"
-                else do
-                  postRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"
-                  let number = Number.toText $ Issue.issueNumber issue
-                  node <- Reader.runReaderT (Issue.readIssueFile issue) stateRef
-                  let text = CMark.nodeToCommonmark [] Nothing node
-                  let list = Listmonk.list listmonk
-                  let campaign =
-                        Campaign
-                          { campaignBody = "# Haskell Weekly\n\n## Issue " <> number <> "\n\n" <> text,
-                            campaignContentType = Just "markdown",
-                            campaignLists = pure list,
-                            campaignName = name,
-                            campaignSubject = "Issue " <> number
-                          }
-                  postResponse <-
-                    Client.httpLbs
-                      ( Client.applyBasicAuth
-                          username
-                          password
-                          postRequest
-                            { Client.method = Http.methodPost,
-                              Client.requestBody = Client.RequestBodyLBS $ Aeson.encode campaign,
-                              Client.requestHeaders = [(Http.hContentType, "application/json")]
-                            }
-                      )
-                      (State.manager state)
-                  case Aeson.eitherDecode $ Client.responseBody postResponse of
-                    Left err -> putStrLn $ "[worker] failed to parse campaign: " <> err
-                    Right result -> putStrLn $ "[worker] created campaign " <> show (resultId $ payloadData result)
+  let listmonk = Config.listmonk $ State.config state
+  let maybeLatest =
+        Maybe.listToMaybe
+          . List.sortOn (Ord.Down . Issue.issueDate)
+          . Map.elems
+          $ State.issues state
+  case maybeLatest of
+    Nothing -> putStrLn "[worker] no issues"
+    Just issue -> do
+      let url = Listmonk.url listmonk
+      getRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"
+      let username = Encoding.encodeUtf8 $ Listmonk.username listmonk
+      let password = Encoding.encodeUtf8 $ Listmonk.password listmonk
+      let name = "hwn-" <> Date.toShortText (Issue.issueDate issue)
+      -- `?query=x` becomes `like '%x%'`, so this will match any substring.
+      -- That's why we search for `hwn-YYYY-MM-DD` rather than `issue-NNN`.
+      let query = Http.renderQuery True [("query", Just $ Encoding.encodeUtf8 name)]
+      getResponse <-
+        Client.httpLbs
+          (Client.applyBasicAuth username password getRequest) {Client.queryString = query}
+          (State.manager state)
+      case Aeson.eitherDecode $ Client.responseBody getResponse of
+        Left err -> putStrLn $ "[worker] failed to parse campaigns: " <> err
+        Right campaigns -> do
+          if campaignsTotal (payloadData campaigns) /= 0
+            then putStrLn $ "[worker] campaign " <> show name <> " already exists"
+            else do
+              postRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"
+              let number = Number.toText $ Issue.issueNumber issue
+              node <- Reader.runReaderT (Issue.readIssueFile issue) stateRef
+              let text = CMark.nodeToCommonmark [] Nothing node
+              let list = Listmonk.list listmonk
+              let campaign =
+                    Campaign
+                      { campaignBody = "# Haskell Weekly\n\n## Issue " <> number <> "\n\n" <> text,
+                        campaignContentType = Just "markdown",
+                        campaignLists = pure list,
+                        campaignName = name,
+                        campaignSubject = "Issue " <> number
+                      }
+              postResponse <-
+                Client.httpLbs
+                  ( Client.applyBasicAuth
+                      username
+                      password
+                      postRequest
+                        { Client.method = Http.methodPost,
+                          Client.requestBody = Client.RequestBodyLBS $ Aeson.encode campaign,
+                          Client.requestHeaders = [(Http.hContentType, "application/json")]
+                        }
+                  )
+                  (State.manager state)
+              case Aeson.eitherDecode $ Client.responseBody postResponse of
+                Left err -> putStrLn $ "[worker] failed to parse campaign: " <> err
+                Right result -> putStrLn $ "[worker] created campaign " <> show (resultId $ payloadData result)
   Concurrent.threadDelay $ 60 * 1000 * 1000
 
 newtype Payload a = Payload

--- a/source/library/HW/Worker.hs
+++ b/source/library/HW/Worker.hs
@@ -53,7 +53,7 @@ worker stateRef = Monad.forever $ do
       case Aeson.eitherDecode $ Client.responseBody getResponse of
         Left err -> putStrLn $ "[worker] failed to parse campaigns: " <> err
         Right campaigns -> do
-          if campaignsTotal (payloadData campaigns) /= 0
+          if campaignsTotal (payloadData campaigns) > 0
             then putStrLn $ "[worker] campaign " <> show name <> " already exists"
             else do
               postRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"


### PR DESCRIPTION
I'm interested in moving off Mailchimp. My primary motivation is cost. Also Mailchimp offers many features I don't need, and using a third-party service has privacy implications that I'd prefer to avoid. 

I'm considering [listmonk](https://listmonk.app) as an alternative. I would run listmonk on [Fly](https://fly.io), which I use for other projects. Emails would actually be sent by [Amazon SES](https://aws.amazon.com/ses/), but that's just configured within listmonk. 

This PR adds a worker that creates a campaign in listmonk for the most recent issue of the newsletter. Sending is not (yet) automatic; the `send_at` field needs to be set for that to happen. I will keep sending manual until I can confirm that I've migrated everyone over without any problems. 

There isn't really anything left to do here in this PR. I need to set up listmonk itself, which will live in a separate repository under this organization. But that will basically just be a Fly config. 