### PR TITLE
Forbid script sources

### DIFF
--- a/source/library/HW/Middleware.hs
+++ b/source/library/HW/Middleware.hs
@@ -197,7 +197,6 @@ contentSecurityPolicy maybeListmonk =
       "frame-ancestors 'none'",
       "img-src data: 'self'",
       "media-src https://media.haskellweekly.news 'self'",
-      "script-src 'unsafe-inline'",
       "style-src 'self'"
     ]
 


### PR DESCRIPTION
Effectively reverts part of fd4c41416c33b21fba79d45a202bbc658a385495.

Haskell Weekly used to have JS for the survey, but currently it does not serve any JS. 