### PR TITLE
Enable link tracking

### DIFF
--- a/source/library/HW/Markdown.hs
+++ b/source/library/HW/Markdown.hs
@@ -43,3 +43,12 @@ toSlug =
         . Text.map (\c -> if p c then c else ' ')
         . Text.toLower
         . Text.unwords
+
+trackLinks :: Markdown -> Markdown
+trackLinks node =
+  let CMark.Node posInfo nodeType nodes = node
+      newNodes = fmap trackLinks nodes
+      newNodeType = case nodeType of
+        CMark.LINK url title -> CMark.LINK (url <> "@TrackLink") title
+        _ -> nodeType
+   in CMark.Node posInfo newNodeType newNodes

--- a/source/library/HW/Worker.hs
+++ b/source/library/HW/Worker.hs
@@ -15,6 +15,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
 import qualified Data.Time as Time
 import qualified HW.Handler.Issue as Issue
+import qualified HW.Markdown as Markdown
 import qualified HW.Type.Config as Config
 import qualified HW.Type.Date as Date
 import qualified HW.Type.Issue as Issue
@@ -63,7 +64,7 @@ worker stateRef = Monad.forever $ do
                   postRequest <- Client.parseRequest . Text.unpack $ url <> "/api/campaigns"
                   let number = Issue.issueNumber issue
                   node <- Reader.runReaderT (Issue.readIssueFile issue) stateRef
-                  let text = CMark.nodeToCommonmark [] Nothing node
+                  let text = CMark.nodeToCommonmark [] Nothing $ Markdown.trackLinks node
                   let list = Listmonk.list listmonk
                   let campaign =
                         Campaign
@@ -72,12 +73,12 @@ worker stateRef = Monad.forever $ do
                                 "\n\n"
                                 [ "# [Haskell Weekly]("
                                     <> Route.toText (Config.baseUrl config) Route.Index
-                                    <> ")",
+                                    <> "@TrackLink)",
                                   "## [Issue "
                                     <> Number.toText number
                                     <> "]("
                                     <> Route.toText (Config.baseUrl config) (Route.Issue number)
-                                    <> ")",
+                                    <> "@TrackLink)",
                                   text
                                 ],
                             campaignContentType = Just "markdown",


### PR DESCRIPTION
This enables link tracking _only_ in emails. It uses the `...@TrackLink` "function" described here: https://listmonk.app/docs/templating/#functions

If I decide to enable this, I will also add `{{ TrackView }}` to the template. Both options track activity without tracking individual users, as described here: https://listmonk.app/docs/concepts/#tracking-pixel

At the beginning of last year, I disabled link tracking in Mailchimp. I did this because it routed all links through `news.us10.list-manage.com`, which didn't play nice with iCloud Private Relay (and probably others). With listmonk, the links will go through `listmonk.haskellweekly.news`, which is hopefully more palatable. 

More generally, open tracking is not very effective anymore. Apple Mail, for example, loads images through a proxy at an effectively random time, regardless of whether or not the client actually opens the email. Click tracking is more effective since if a user clicks on the link, it will get tracked. There may be false positives though. 

I know that some people oppose tracking of any type for any reason. To those people, I'll say: Haskell Weekly also offers an RSS feed (without tracking), and I post each issue to the Haskell Discourse. Plus of course the website itself is publicly available without any tracking. And this new tracking through listmonk is entirely first party; nothing is going to Intuit or Google. 

Email open and click tracking is useful to me primarily to gauge effectiveness of ads, which are the primary way that I support Haskell Weekly. It is possible that switching to listmonk and SES has lowered costs enough that I do not need to run ads anymore, in which case tracking is basically pointless (other than for vanity metrics). 