### PR TITLE
Update default branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - haskellweekly
+      - main
   push:
     branches:
-      - haskellweekly
+      - main
 
 jobs:
 


### PR DESCRIPTION
I updated the default branch from `haskellweekly` to `main`. I forgot that I also needed to update the GitHub Actions configuration. That's what this PR does. 