### PR TITLE
Switch to refs/heads/main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,14 +142,14 @@ jobs:
         with:
           context: docker
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.ref == 'refs/heads/haskellweekly' }}
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
 
   aws:
     needs: build
     runs-on: ubuntu-latest
     name: Deploy to AWS
-    if: github.ref == 'refs/heads/haskellweekly'
+    if: github.ref == 'refs/heads/main'
     steps:
 
       - uses: actions/checkout@v4
@@ -171,7 +171,7 @@ jobs:
     needs: docker
     runs-on: ubuntu-latest
     name: Deploy to Fly.io
-    if: github.ref == 'refs/heads/haskellweekly'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
@tfausak it looks like merging #357 didn't cause the deployment to go out, judging by this: https://github.com/haskellweekly/haskellweekly/actions/runs/10937836694

I think it's because `ci.yaml` is still pointing to the `haskellweekly` branch for those steps. I am tempted to merge this right now but hopefully there is not a lot of harm in waiting for when you're around either.