### PR TITLE
Set up hCaptcha

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,7 @@ image = "ghcr.io/haskellweekly/haskellweekly:latest"
 [env]
 BASE_URL = "https://haskellweekly.news"
 LISTMONK_LIST = "3"
+LISTMONK_SITEKEY = "52d006fe-18bc-40d2-bec2-d78e9b40f1bc"
 LISTMONK_URL = "https://listmonk.haskellweekly.news"
 LISTMONK_UUID = "4295554f-8f91-4864-92fa-a75a7315d630"
 

--- a/haskellweekly.cabal
+++ b/haskellweekly.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: haskellweekly
-version: 0.2024.9.19
+version: 0.2024.9.24
 synopsis: Publishes curated news about Haskell.
 description:
   Haskell Weekly publishes curated news about the Haskell programming language.

--- a/source/library/HW/Middleware.hs
+++ b/source/library/HW/Middleware.hs
@@ -188,14 +188,17 @@ contentSecurityPolicy maybeListmonk =
   Text.intercalate
     "; "
     [ "base-uri 'none'",
+      "connect-src https://hcaptcha.com, https://*.hcaptcha.com",
       "default-src 'none'",
       "form-action https://duckduckgo.com "
         <> maybe "" Listmonk.url maybeListmonk
         <> " 'self'",
       "frame-ancestors 'none'",
+      "frame-src https://hcaptcha.com, https://*.hcaptcha.com",
       "img-src data: 'self'",
       "media-src https://media.haskellweekly.news 'self'",
-      "style-src 'self'"
+      "script-src https://hcaptcha.com, https://*.hcaptcha.com",
+      "style-src https://hcaptcha.com, https://*.hcaptcha.com 'self'"
     ]
 
 -- | The value of the @Permissions-Policy@ header.

--- a/source/library/HW/Template/Newsletter.hs
+++ b/source/library/HW/Template/Newsletter.hs
@@ -67,7 +67,6 @@ callToAction baseUrl maybeListmonk =
       "."
     Monad.forM_ maybeListmonk $ \listmonk -> Html.form_
       [ Html.action_ $ Listmonk.url listmonk <> "/subscription/form",
-        Html.class_ "flex",
         Html.method_ "post"
       ]
       $ do
@@ -80,19 +79,32 @@ callToAction baseUrl maybeListmonk =
             Html.type_ "hidden",
             Html.value_ . Uuid.toText $ Listmonk.uuid listmonk
           ]
-        Html.input_
-          [ Html.makeAttributes "aria-label" "Email address",
-            Html.class_ "ba br0 b--silver input-reset pa3 flex-auto",
-            Html.name_ "email",
-            Html.placeholder_ "you@example.com",
-            Html.required_ "required",
-            Html.type_ "email"
-          ]
-        Html.button_
-          [ Html.class_ "b bn bg-dark-blue input-reset pa3 pointer white",
-            Html.type_ "submit"
-          ]
-          "Subscribe"
+        Html.div_ [Html.class_ "captcha tc"] $ do
+          Html.div_
+            [ Html.class_ "h-captcha",
+              Html.data_ "sitekey" . Uuid.toText $ Listmonk.sitekey listmonk
+            ]
+            ""
+          Html.script_
+            [ Html.async_ "async",
+              Html.defer_ "defer",
+              Html.src_ "https://js.hcaptcha.com/1/api.js"
+            ]
+            (mempty :: Html.Html ())
+        Html.div_ [Html.class_ "flex"] $ do
+          Html.input_
+            [ Html.makeAttributes "aria-label" "Email address",
+              Html.class_ "ba br0 b--silver input-reset pa3 flex-auto",
+              Html.name_ "email",
+              Html.placeholder_ "you@example.com",
+              Html.required_ "required",
+              Html.type_ "email"
+            ]
+          Html.button_
+            [ Html.class_ "b bn bg-dark-blue input-reset pa3 pointer white",
+              Html.type_ "submit"
+            ]
+            "Subscribe"
 
 issueTemplate :: BaseUrl.BaseUrl -> Issue.Issue -> Html.Html ()
 issueTemplate baseUrl issue = Html.li_ $ do

--- a/source/library/HW/Type/Listmonk.hs
+++ b/source/library/HW/Type/Listmonk.hs
@@ -9,6 +9,7 @@ import qualified Text.Read as Read
 data Listmonk = Listmonk
   { list :: Int,
     password :: Text.Text,
+    sitekey :: Uuid.UUID,
     url :: Text.Text,
     username :: Text.Text,
     uuid :: Uuid.UUID
@@ -23,6 +24,11 @@ getListmonk = MaybeT.runMaybeT $ do
       Nothing -> fail $ "invalid LISTMONK_LIST: " <> show string
       Just list -> pure list
   password <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_PASSWORD"
+  sitekey <- do
+    string <- MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_SITEKEY"
+    case Uuid.fromString string of
+      Nothing -> fail $ "invalid LISTMONK_SITEKEY: " <> show string
+      Just sitekey -> pure sitekey
   url <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_URL"
   username <- fmap Text.pack . MaybeT.MaybeT $ Environment.lookupEnv "LISTMONK_USERNAME"
   uuid <- do
@@ -30,4 +36,4 @@ getListmonk = MaybeT.runMaybeT $ do
     case Uuid.fromString string of
       Nothing -> fail $ "invalid LISTMONK_UUID: " <> show string
       Just uuid -> pure uuid
-  pure Listmonk {list, password, url, username, uuid}
+  pure Listmonk {list, password, sitekey, url, username, uuid}


### PR DESCRIPTION
In order to prevent people from spamming the newsletter sign up form, I need some way to prevent bogus submissions. listmonk supports hCaptcha natively, so I just set that up. 

This follows from #336. 