### PR TITLE
Remove caches

### DIFF
--- a/source/library/HW/Application.hs
+++ b/source/library/HW/Application.hs
@@ -3,7 +3,6 @@
 module HW.Application where
 
 import qualified Control.Monad.Trans.Reader as Reader
-import qualified Data.IORef as IORef
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text
@@ -32,11 +31,11 @@ import qualified Network.Wai as Wai
 -- | The whole application. From a high level, this is responsible for checking
 -- the request method and path. If those route to an appropriate handler, this
 -- calls that handler and returns the response.
-application :: IORef.IORef State.State -> Wai.Application
-application ref request respond =
+application :: State.State -> Wai.Application
+application state request respond =
   case (requestMethod request, requestRoute request) of
     ("GET", Just routeOrRedirect) -> do
-      response <- Reader.runReaderT (handle routeOrRedirect request) ref
+      response <- Reader.runReaderT (handle routeOrRedirect request) state
       respond response
     _ -> respond Common.notFound
 

--- a/source/library/HW/Main.hs
+++ b/source/library/HW/Main.hs
@@ -4,7 +4,6 @@
 module HW.Main where
 
 import qualified Control.Concurrent.Async as Async
-import qualified Data.IORef as IORef
 import qualified Data.Version as Version
 import qualified HW.Server as Server
 import qualified HW.Type.Config as Config
@@ -23,7 +22,6 @@ defaultMain = do
       <> " ..."
   config <- Config.getConfig
   state <- State.configToState config
-  stateRef <- IORef.newIORef state
   Async.race_
-    (Server.server stateRef)
-    (Worker.worker stateRef)
+    (Server.server state)
+    (Worker.worker state)

--- a/source/library/HW/Server.hs
+++ b/source/library/HW/Server.hs
@@ -2,7 +2,6 @@
 module HW.Server where
 
 import qualified Data.ByteString as ByteString
-import qualified Data.IORef as IORef
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Version as Version
@@ -17,13 +16,12 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Paths_haskellweekly as Package
 
 -- | Starts up the server. This function never returns.
-server :: IORef.IORef State.State -> IO ()
-server ref = do
-  state <- IORef.readIORef ref
+server :: State.State -> IO ()
+server state = do
   let config = State.config state
   Warp.runSettings (configToSettings config)
-    . Middleware.middleware ref
-    $ Application.application ref
+    . Middleware.middleware state
+    $ Application.application state
 
 -- | Converts a Haskell Weekly config into Warp server settings.
 configToSettings :: Config.Config -> Warp.Settings

--- a/source/library/HW/Type/App.hs
+++ b/source/library/HW/Type/App.hs
@@ -3,20 +3,17 @@ module HW.Type.App where
 import qualified Control.Monad.IO.Class as IO
 import qualified Control.Monad.Trans.Reader as Reader
 import qualified Data.ByteString as ByteString
-import qualified Data.IORef as IORef
 import qualified HW.Type.Config as Config
 import qualified HW.Type.State as State
 import qualified System.FilePath as FilePath
 
-type App = Reader.ReaderT (IORef.IORef State.State) IO
+type App = Reader.ReaderT State.State IO
 
 getConfig :: App Config.Config
 getConfig = fmap State.config getState
 
 getState :: App State.State
-getState = do
-  ref <- Reader.ask
-  IO.liftIO $ IORef.readIORef ref
+getState = Reader.ask
 
 -- | Reads a data file by using the data directory in the state's config. This
 -- returns nothing if the file doesn't exist and raises an exception for all

--- a/source/library/HW/Type/App.hs
+++ b/source/library/HW/Type/App.hs
@@ -19,10 +19,7 @@ getState = Reader.ask
 -- returns nothing if the file doesn't exist and raises an exception for all
 -- other failure modes.
 readDataFile :: FilePath -> App ByteString.ByteString
-readDataFile = readDataFileWithoutCache
-
-readDataFileWithoutCache :: FilePath -> App ByteString.ByteString
-readDataFileWithoutCache file = do
+readDataFile file = do
   config <- getConfig
   let directory = Config.dataDirectory config
       path = FilePath.combine directory file

--- a/source/library/HW/Type/App.hs
+++ b/source/library/HW/Type/App.hs
@@ -4,7 +4,6 @@ import qualified Control.Monad.IO.Class as IO
 import qualified Control.Monad.Trans.Reader as Reader
 import qualified Data.ByteString as ByteString
 import qualified Data.IORef as IORef
-import qualified Data.Map as Map
 import qualified HW.Type.Config as Config
 import qualified HW.Type.State as State
 import qualified System.FilePath as FilePath
@@ -23,18 +22,7 @@ getState = do
 -- returns nothing if the file doesn't exist and raises an exception for all
 -- other failure modes.
 readDataFile :: FilePath -> App ByteString.ByteString
-readDataFile file = do
-  state <- getState
-  case Map.lookup file (State.fileCache state) of
-    Just contents -> pure contents
-    Nothing -> do
-      contents <- readDataFileWithoutCache file
-      stateRef <- Reader.ask
-      IO.liftIO . State.modifyState stateRef $ \oldState ->
-        oldState
-          { State.fileCache = Map.insert file contents $ State.fileCache oldState
-          }
-      pure contents
+readDataFile = readDataFileWithoutCache
 
 readDataFileWithoutCache :: FilePath -> App ByteString.ByteString
 readDataFileWithoutCache file = do

--- a/source/library/HW/Type/State.hs
+++ b/source/library/HW/Type/State.hs
@@ -3,23 +3,17 @@
 module HW.Type.State where
 
 import qualified Data.IORef as IORef
-import qualified Data.Map as Map
-import qualified Data.Text as Text
-import qualified Data.Time as Time
 import qualified HW.Episodes as Episodes
 import qualified HW.Issues as Issues
 import qualified HW.Type.Config as Config
 import qualified Network.HTTP.Client as Client
 import qualified Network.HTTP.Client.TLS as Tls
-import qualified Network.Wai as Wai
 
 data State = State
   { config :: Config.Config,
     episodes :: Episodes.Episodes,
     issues :: Issues.Issues,
-    manager :: Client.Manager,
-    responseCache ::
-      Map.Map (Text.Text, Text.Text) (Time.UTCTime, Wai.Response)
+    manager :: Client.Manager
   }
 
 -- | Builds up the state using the given config. If anything goes wrong, this
@@ -34,8 +28,7 @@ configToState config = do
       { config,
         episodes,
         issues,
-        manager,
-        responseCache = Map.empty
+        manager
       }
 
 modifyState :: IORef.IORef State -> (State -> State) -> IO ()

--- a/source/library/HW/Type/State.hs
+++ b/source/library/HW/Type/State.hs
@@ -2,7 +2,6 @@
 -- Haskell Weekly server.
 module HW.Type.State where
 
-import qualified Data.IORef as IORef
 import qualified HW.Episodes as Episodes
 import qualified HW.Issues as Issues
 import qualified HW.Type.Config as Config
@@ -30,7 +29,3 @@ configToState config = do
         issues,
         manager
       }
-
-modifyState :: IORef.IORef State -> (State -> State) -> IO ()
-modifyState ref modify =
-  IORef.atomicModifyIORef' ref $ \state -> (modify state, ())

--- a/source/library/HW/Type/State.hs
+++ b/source/library/HW/Type/State.hs
@@ -2,7 +2,6 @@
 -- Haskell Weekly server.
 module HW.Type.State where
 
-import qualified Data.ByteString as ByteString
 import qualified Data.IORef as IORef
 import qualified Data.Map as Map
 import qualified Data.Text as Text
@@ -17,7 +16,6 @@ import qualified Network.Wai as Wai
 data State = State
   { config :: Config.Config,
     episodes :: Episodes.Episodes,
-    fileCache :: Map.Map FilePath ByteString.ByteString,
     issues :: Issues.Issues,
     manager :: Client.Manager,
     responseCache ::
@@ -35,7 +33,6 @@ configToState config = do
     State
       { config,
         episodes,
-        fileCache = Map.empty,
         issues,
         manager,
         responseCache = Map.empty


### PR DESCRIPTION
These consume more and more memory until the server crashes. I can't prove it, but I don't think they help anything anyway. The server itself is already behind CloudFront, so responses get cached there. 